### PR TITLE
Enable layer override in color transcode

### DIFF
--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -519,6 +519,13 @@ class ExtractOIIOTranscodeOutputModel(BaseSettingsModel):
             " to the created representation."
         )
     )
+    override_layer: str = SettingsField(
+        "",
+        title="Override Layer",
+        description=(
+            "EXR layer to use for transcoding (e.g. 'composite')."
+        ),
+    )
 
 
 class ExtractOIIOTranscodeProfileModel(BaseSettingsModel):


### PR DESCRIPTION
## Summary
- add new `override_layer` option to ExtractOIIOTranscode settings for UI
- previous commit added support in transcoding functions and plugin

## Testing
- `PYTHONPATH=$PWD/client:$PYTHONPATH pytest -q` *(fails: ModuleNotFoundError: No module named 'qargparse')*

------
https://chatgpt.com/codex/tasks/task_e_68721185e3608325a22b1552637d373b