### PR TITLE
Enable layer override in color transcode

### DIFF
--- a/client/ayon_core/lib/transcoding.py
+++ b/client/ayon_core/lib/transcoding.py
@@ -529,7 +529,8 @@ def should_convert_for_ffmpeg(src_filepath):
 def convert_input_paths_for_ffmpeg(
     input_paths,
     output_dir,
-    logger=None
+    logger=None,
+    override_layer=None,
 ):
     """Convert source file to format supported in ffmpeg.
 
@@ -548,6 +549,7 @@ def convert_input_paths_for_ffmpeg(
         output_dir (str): Path to directory where output will be rendered.
             Must not be same as input's directory.
         logger (logging.Logger): Logger used for logging.
+        override_layer (str | None): Name of the EXR layer to override.
 
     Raises:
         ValueError: If input filepath has extension not supported by function.
@@ -574,7 +576,10 @@ def convert_input_paths_for_ffmpeg(
         compression = "none"
 
     # Collect channels to export
-    input_arg, channels_arg = get_oiio_input_and_channel_args(input_info)
+    input_arg, channels_arg = get_oiio_input_and_channel_args(
+        input_info,
+        override_layer=override_layer,
+    )
 
     for input_path in input_paths:
         # Prepare subprocess arguments
@@ -975,6 +980,7 @@ def convert_colorspace(
     view=None,
     display=None,
     additional_command_args=None,
+    override_layer=None,
     logger=None,
 ):
     """Convert source file from one color space to another.
@@ -1007,7 +1013,10 @@ def convert_colorspace(
     input_info = get_oiio_info_for_input(input_path, logger=logger)
 
     # Collect channels to export
-    input_arg, channels_arg = get_oiio_input_and_channel_args(input_info)
+    input_arg, channels_arg = get_oiio_input_and_channel_args(
+        input_info,
+        override_layer=override_layer,
+    )
 
     # Prepare subprocess arguments
     oiio_cmd = get_oiio_tool_args(
@@ -1283,7 +1292,11 @@ def convert_color_values(application, color_value):
         )
 
 
-def get_oiio_input_and_channel_args(oiio_input_info, alpha_default=None):
+def get_oiio_input_and_channel_args(
+    oiio_input_info,
+    alpha_default=None,
+    override_layer=None,
+):
     """Get input and channel arguments for oiiotool.
     Args:
         oiio_input_info (dict): Information about input from oiio tool.
@@ -1293,14 +1306,31 @@ def get_oiio_input_and_channel_args(oiio_input_info, alpha_default=None):
         tuple[str, str]: Tuple of input and channel arguments.
     """
     channel_names = oiio_input_info["channelnames"]
-    review_channels = get_convert_rgb_channels(channel_names)
 
-    if review_channels is None:
-        raise ValueError(
-            "Couldn't find channels that can be used for conversion."
+    if override_layer:
+        layers = get_review_info_by_layer_name(channel_names)
+        selected = next(
+            (item for item in layers if item["name"].lower() == override_layer.lower()),
+            None,
         )
+        if not selected:
+            raise ValueError(f"Layer '{override_layer}' not found")
+        rc = selected["review_channels"]
+        red, green, blue, alpha = (
+            rc["R"],
+            rc["G"],
+            rc["B"],
+            rc.get("A"),
+        )
+    else:
+        review_channels = get_convert_rgb_channels(channel_names)
 
-    red, green, blue, alpha = review_channels
+        if review_channels is None:
+            raise ValueError(
+                "Couldn't find channels that can be used for conversion."
+            )
+
+        red, green, blue, alpha = review_channels
     input_channels = [red, green, blue]
 
     channels_arg = "R={0},G={1},B={2}".format(red, green, blue)

--- a/client/ayon_core/plugins/publish/extract_review.py
+++ b/client/ayon_core/plugins/publish/extract_review.py
@@ -389,7 +389,8 @@ class ExtractReview(pyblish.api.InstancePlugin):
                 convert_input_paths_for_ffmpeg(
                     input_filepaths,
                     new_staging_dir,
-                    self.log
+                    logger=self.log,
+                    override_layer=layer_name,
                 )
 
             try:

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -519,6 +519,13 @@ class ExtractOIIOTranscodeOutputModel(BaseSettingsModel):
             " to the created representation."
         )
     )
+    override_layer: str = SettingsField(
+        "",
+        title="Override Layer",
+        description=(
+            "EXR layer to use for transcoding (e.g. 'composite')."
+        ),
+    )
 
 
 class ExtractOIIOTranscodeProfileModel(BaseSettingsModel):


### PR DESCRIPTION
## Summary
- add new `override_layer` option to ExtractOIIOTranscode settings for UI
- previous commit added support in transcoding functions and plugin
- fix NameError from missing `override_layer` argument by adding it to `convert_input_paths_for_ffmpeg`
- pass layer name to `convert_input_paths_for_ffmpeg` when converting review inputs

## Testing
- `PYTHONPATH=$PWD/client:$PYTHONPATH pytest -q` *(fails: ModuleNotFoundError: No module named 'ayon_api')*


------
https://chatgpt.com/codex/tasks/task_e_68721185e3608325a22b1552637d373b